### PR TITLE
fixed issue with email system

### DIFF
--- a/SharkEyesCore/models.py
+++ b/SharkEyesCore/models.py
@@ -32,7 +32,7 @@ class FeedbackHistory (models.Model):
             # Use the Django framework's send_mail function to create the email
             # pattern Subject, Body, From, To(as a list)
             #set this to be sent to Flaxen in production
-            send_mail('[Seacast Feedback] ' + each.feedback_title, '\nname: '+ each.feedback_name+ '\nemail: '+ each.feedback_email+ '\nphone: '+ each.feedback_phone+ '\ncomments: '+ each.feedback_comments, 'seacast.mail@gmail.com',
+            send_mail('[Seacast Feedback] ' + each.feedback_title.rstrip(), '\nname: '+ each.feedback_name+ '\nemail: '+ each.feedback_email+ '\nphone: '+ each.feedback_phone+ '\ncomments: '+ each.feedback_comments, 'seacast.mail@gmail.com',
                 [recipient], fail_silently=False)
             each.sent = True
             each.save()


### PR DESCRIPTION
The subject line or header cannot have newlines. If a user presses enter and adds a newline for their subject it was breaking the mail system. I added an .rstrip() to the subject string to remove any trailing characters. None of the other fields are affected by this and don't break if the user adds a newline. 